### PR TITLE
fix(readme): correct code block for nvim-cmp example

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,42 +87,43 @@ If you want to add `<Tab>` completion instead, be sure you don't have a completi
 <details>
    <summary>nvim-cmp</summary>
   
-    ```lua
-    local cmp = require('cmp')
-    local neogen = require('neogen')
+```lua
+local cmp = require('cmp')
+local neogen = require('neogen')
 
-    local t = function(str)
-        return vim.api.nvim_replace_termcodes(str, true, true, true)
-    end
+local t = function(str)
+    return vim.api.nvim_replace_termcodes(str, true, true, true)
+end
 
-    local check_back_space = function()
-        local col = vim.fn.col '.' - 1
-        return col == 0 or vim.fn.getline('.'):sub(col, col):match '%s' ~= nil
-    end
+local check_back_space = function()
+    local col = vim.fn.col '.' - 1
+    return col == 0 or vim.fn.getline('.'):sub(col, col):match '%s' ~= nil
+end
 
-    cmp.setup {
-        ...
+cmp.setup {
+    ...
 
-        -- You must set mapping if you want.
-        mapping = {
-            ["<tab>"] = cmp.mapping(function(fallback)
-                if vim.fn.pumvisible() == 1 then
-                    vim.fn.feedkeys(t("<C-n>"), "n")
-                elseif neogen.jumpable() then
-                    vim.fn.feedkeys(t("<cmd>lua require('neogen').jump_next()<CR>"), "")
-                elseif check_back_space() then
-                    vim.fn.feedkeys(t("<tab>"), "n")
-                else
-                    fallback()
-                end
-            end, {
-                "i",
-                "s",
-            }),
-        },
-        ...
-    }
-    ```
+    -- You must set mapping if you want.
+    mapping = {
+        ["<tab>"] = cmp.mapping(function(fallback)
+            if vim.fn.pumvisible() == 1 then
+                vim.fn.feedkeys(t("<C-n>"), "n")
+            elseif neogen.jumpable() then
+                vim.fn.feedkeys(t("<cmd>lua require('neogen').jump_next()<CR>"), "")
+            elseif check_back_space() then
+                vim.fn.feedkeys(t("<tab>"), "n")
+            else
+                fallback()
+            end
+        end, {
+            "i",
+            "s",
+        }),
+    },
+    ...
+}
+```
+
   </details>
 
 ## Configuration


### PR DESCRIPTION
Hey, so this is just a tiny fix for the readme. It seems that markdown acts in some weird ways when indenting stuff haha