### PR TITLE
Add support for function prototype annotation

### DIFF
--- a/lua/neogen/configurations/c.lua
+++ b/lua/neogen/configurations/c.lua
@@ -37,6 +37,11 @@ local c_function_extractor = function(node)
             node_type = "primitive_type",
             extract = true,
         },
+        {
+            retrieve = "first",
+            node_type = "pointer_declarator",
+            extract = true,
+        },
         c_params,
     }
 
@@ -53,9 +58,11 @@ local c_function_extractor = function(node)
         if res.return_statement then
             -- function implementation
             return res.return_statement
-        elseif res.function_declarator and res.primitive_type and res.primitive_type[1] ~= "void" then
-            -- function prototype
-            return res.primitive_type
+        elseif res.function_declarator and res.primitive_type then
+            if res.primitive_type[1] ~= "void" or res.pointer_declarator then
+                -- function prototype
+                return res.primitive_type
+            end
         end
         -- not found
         return nil

--- a/lua/neogen/configurations/c.lua
+++ b/lua/neogen/configurations/c.lua
@@ -50,11 +50,11 @@ local c_function_extractor = function(node)
     end
 
     local has_return_statement = function()
-        -- function implementation
         if res.return_statement then
+            -- function implementation
             return res.return_statement
-            -- function prototype
         elseif res.function_declarator and res.primitive_type and res.primitive_type[1] ~= "void" then
+            -- function prototype
             return res.primitive_type
         end
         -- not found

--- a/lua/neogen/configurations/c.lua
+++ b/lua/neogen/configurations/c.lua
@@ -33,9 +33,9 @@ local c_function_extractor = function(node)
             },
         },
         {
-          retrieve = "first",
-          node_type = "primitive_type",
-          extract = true,
+            retrieve = "first",
+            node_type = "primitive_type",
+            extract = true,
         },
         c_params,
     }
@@ -50,15 +50,15 @@ local c_function_extractor = function(node)
     end
 
     local has_return_statement = function()
-      -- function implementation
-      if res.return_statement then
-        return res.return_statement
-      -- function prototype
-      elseif res.function_declarator and res.primitive_type and res.primitive_type[1] ~= "void" then
-        return res.primitive_type
-      end
-      -- not found
-      return nil
+        -- function implementation
+        if res.return_statement then
+            return res.return_statement
+            -- function prototype
+        elseif res.function_declarator and res.primitive_type and res.primitive_type[1] ~= "void" then
+            return res.primitive_type
+        end
+        -- not found
+        return nil
     end
 
     return {

--- a/lua/neogen/configurations/c.lua
+++ b/lua/neogen/configurations/c.lua
@@ -52,12 +52,12 @@ end
 
 return {
     parent = {
-        func = { "function_declaration", "function_definition" },
+        func = { "function_declaration", "function_definition", "declaration" },
     },
 
     data = {
         func = {
-            ["function_declaration|function_definition"] = {
+            ["function_declaration|function_definition|declaration"] = {
                 ["0"] = {
                     extract = c_function_extractor,
                 },

--- a/lua/neogen/configurations/c.lua
+++ b/lua/neogen/configurations/c.lua
@@ -32,6 +32,11 @@ local c_function_extractor = function(node)
                 { retrieve = "first", node_type = "return_statement", extract = true },
             },
         },
+        {
+          retrieve = "first",
+          node_type = "primitive_type",
+          extract = true,
+        },
         c_params,
     }
 
@@ -44,9 +49,21 @@ local c_function_extractor = function(node)
         res = vim.tbl_deep_extend("keep", res, subres)
     end
 
+    local has_return_statement = function()
+      -- function implementation
+      if res.return_statement then
+        return res.return_statement
+      -- function prototype
+      elseif res.function_declarator and res.primitive_type and res.primitive_type[1] ~= "void" then
+        return res.primitive_type
+      end
+      -- not found
+      return nil
+    end
+
     return {
         parameters = res.identifier,
-        return_statement = res.return_statement,
+        return_statement = has_return_statement(),
     }
 end
 


### PR DESCRIPTION
Hi,

Thanks for publishing this plugin! I wanted to use it to annotate function prototypes in C header files so I added support for this. The original functionality for the C language type should still be preserved and I've tested some edge cases locally. Will do more extensive testing tomorrow, so I'll leave this as draft for now.