### PR TITLE
Write annotation before template declarations (C++)

### DIFF
--- a/lua/neogen/configurations/c.lua
+++ b/lua/neogen/configurations/c.lua
@@ -104,6 +104,23 @@ return {
         },
     },
 
+	locator = function(node_info, nodes_to_match)
+		local result = neogen.default_locator(node_info, nodes_to_match)
+		if not result then
+			return nil
+		end
+		-- if the function happens to be a function template we want to place
+		-- the annotation before the template statement and extract the
+		-- template parameters names as well
+		if node_info.current:parent() == nil then
+			return result
+		end
+		if node_info.current:parent():type() == "template_declaration" then
+			return result:parent()
+		end
+		return result
+	end,
+
     -- Use default granulator and generator
     granulator = nil,
     generator = nil,


### PR DESCRIPTION
Prior to this fix the annotation was written after the template
declaration in case the cursor did not happen to be on the same line as
the template declaration.

For example the following code

```cpp
template <typename T>
void foo(T bar); // cursor placed on this line
```

resulted in

```cpp
template <typename T>
/**
 * @brief 
 *
 * @param bar 
 */
void foo(T bar);
```

and with this PR applied it results in

```cpp
/**
 * @brief 
 *
 * @tparam T 
 * @param bar 
 */
template <typename T>
void foo(T bar);
```

This only happened when the template declaration was on a separate line, of
course.