### PR TITLE
feat(init) switch language on setup

### DIFF
--- a/lua/neogen/init.lua
+++ b/lua/neogen/init.lua
@@ -59,6 +59,7 @@ neogen.setup = function(opts)
     -- Export module
     _G.neogen = neogen
 
+    -- Force configuring current language again when doing `setup` call.
     helpers.switch_language()
 end
 

--- a/lua/neogen/init.lua
+++ b/lua/neogen/init.lua
@@ -58,6 +58,8 @@ neogen.setup = function(opts)
 
     -- Export module
     _G.neogen = neogen
+
+    helpers.switch_language()
 end
 
 --- Neogen Usage


### PR DESCRIPTION
If you call `setup` after `BufRead` the `configuration` table wont have been updated and you'll get an error. This calls `switch_language` at the end of `setup` to fix that.