### PR TITLE
Add space before numpydoc colon

### DIFF
--- a/lua/neogen/configurations/python.lua
+++ b/lua/neogen/configurations/python.lua
@@ -285,15 +285,15 @@ return {
             { "has_identifier", "----------", { type = { "func" } } },
             {
                 "parameters",
-                "%s: $1",
+                "%s : $1",
                 { after_each = "    $1", type = { "func" } },
             },
             {
                 { "identifier", "type" },
-                "%s: %s",
+                "%s : %s",
                 { after_each = "    $1", required = "typed_parameters", type = { "func" } },
             },
-            { "attributes", "%s: $1", { before_first_item = { "", "Attributes", "----------" } } },
+            { "attributes", "%s : $1", { before_first_item = { "", "Attributes", "----------" } } },
             { "has_return", "", { type = { "func" } } },
             { "has_return", "Returns", { type = { "func" } } },
             { "has_return", "-------", { type = { "func" } } },


### PR DESCRIPTION
In the `numpydoc` docstring style, there is supposed to be a space before the colon separating the parameter and type.[^1][^2] (even tho it looks a little weird compared to the type annotations...)

I added that missing space in this PR.

[^1]: https://numpydoc.readthedocs.io/en/latest/format.html

[^2]: https://numpydoc.readthedocs.io/en/latest/format.html