### PR TITLE
Improve Godoc support

### DIFF
--- a/lua/neogen/configurations/go.lua
+++ b/lua/neogen/configurations/go.lua
@@ -1,17 +1,48 @@
 local template = require("neogen.template")
+local extractors = require("neogen.utilities.extractors")
+local nodes_utils = require("neogen.utilities.nodes")
 
 return {
     parent = {
-        func = { "function_declaration" },
-        type = { "package_clause", "const_declaration", "var_declaration" },
+        func = { "function_declaration", "method_declaration" },
+        type = { "package_clause", "const_declaration", "var_declaration", "type_declaration" },
     },
 
     data = {
         func = {
             ["function_declaration"] = {
                 ["0"] = {
-                    extract = function()
-                        return {}
+                    extract = function(node)
+                        local tree = {
+                            {
+                                retrieve = "first",
+                                node_type = "identifier",
+                                extract = "true",
+                            }
+                        }
+                        local nodes = nodes_utils:matching_nodes_from(node, tree)
+                        local res = extractors:extract_from_matched(nodes)
+                        return {
+                            func_name = res.identifier,
+                        }
+                    end,
+                },
+            },
+            ["method_declaration"] = {
+                ["0"] = {
+                    extract = function(node)
+                        local tree = {
+                            {
+                                retrieve = "first",
+                                node_type = "field_identifier",
+                                extract = "true",
+                            }
+                        }
+                        local nodes = nodes_utils:matching_nodes_from(node, tree)
+                        local res = extractors:extract_from_matched(nodes)
+                        return {
+                            func_name = res.field_identifier,
+                        }
                     end,
                 },
             },
@@ -21,6 +52,26 @@ return {
                 ["0"] = {
                     extract = function()
                         return {}
+                    end,
+                },
+            },
+            ["type_declaration"] = {
+                ["0"] = {
+                    extract = function(node)
+                        local tree = {
+                            {
+                                retrieve = "all",
+                                node_type = "type_spec",
+                                subtree = {
+                                    { retrieve = "first", node_type = "type_identifier", extract = true },
+                                },
+                            }
+                        }
+                        local nodes = nodes_utils:matching_nodes_from(node, tree)
+                        local res = extractors:extract_from_matched(nodes)
+                        return {
+                            type_name = res.type_identifier,
+                        }
                     end,
                 },
             },

--- a/lua/neogen/templates/godoc.lua
+++ b/lua/neogen/templates/godoc.lua
@@ -1,3 +1,5 @@
 return {
     { nil, " $1", { no_results = true } },
+    { "func_name", " %s $1", { type = { "func" }}},
+    { "type_name", " %s $1", { type = { "type" }}},
 }


### PR DESCRIPTION
Godoc recommends, as per https://go.dev/blog/godoc , that documentation
comments start with the name of the thing being documented.

This adds that, as well as better support for structs and interfaces.