### PR TITLE
fix: csharp parameters

### DIFF
--- a/lua/neogen/configurations/cs.lua
+++ b/lua/neogen/configurations/cs.lua
@@ -29,7 +29,7 @@ return {
                                         retrieve = "all",
                                         node_type = "parameter",
                                         subtree = {
-                                            { position = 2, extract = true },
+                                            { position = 2, extract = true, as = i.Parameter },
                                         },
                                     },
                                 },


### PR DESCRIPTION
I don't get parameter names without this, at least in Linux. Tested in a bare `dotnet` console app.