### PR TITLE
C# improvements

### DIFF
--- a/lua/neogen/configurations/cs.lua
+++ b/lua/neogen/configurations/cs.lua
@@ -35,6 +35,19 @@ return {
                                 },
                             },
                             {
+                                retrieve = "first",
+                                node_type = "type_parameter_list",
+                                subtree = {
+                                    {
+                                        retrieve = "all",
+                                        node_type = "type_parameter",
+                                        subtree = {
+                                            { position = 1, extract = true, as = i.Tparam },
+                                        },
+                                    },
+                                },
+                            },
+                            {
                                 position = 1,
                                 extract = true,
                                 as = i.Return
@@ -54,8 +67,26 @@ return {
         class = {
             ["class_declaration|interface_declaration"] = {
                 ["0"] = {
-                    extract = function()
-                        return {}
+                    extract = function(node)
+                        local tree = {
+                            {
+                                retrieve = "first",
+                                node_type = "type_parameter_list",
+                                subtree = {
+                                    {
+                                        retrieve = "all",
+                                        node_type = "type_parameter",
+                                        subtree = {
+                                            { position = 1, extract = true, as = i.Tparam },
+                                        },
+                                    },
+                                },
+                            },
+                        }
+                        local nodes = nodes_utils:matching_nodes_from(node, tree)
+                        local res = extractors:extract_from_matched(nodes)
+                        res.identifier = res["_"]
+                        return res
                     end,
                 },
             },

--- a/lua/neogen/configurations/cs.lua
+++ b/lua/neogen/configurations/cs.lua
@@ -12,7 +12,7 @@ return {
             "delegate_declaration",
             "conversion_operator_declaration",
         },
-        class = { "class_declaration" },
+        class = { "class_declaration", "interface_declaration" },
         type = { "field_declaration", "property_declaration", "event_field_declaration", "indexer_declaration" },
     },
     data = {
@@ -35,20 +35,16 @@ return {
                                 },
                             },
                             {
-                                retrieve = "first",
-                                node_type = "block",
-                                subtree = {
-                                    {
-                                        retrieve = "first",
-                                        recursive = true,
-                                        node_type = "return_statement",
-                                        extract = true,
-                                    },
-                                },
+                                position = 1,
+                                extract = true,
+                                as = i.Return
                             },
                         }
                         local nodes = nodes_utils:matching_nodes_from(node, tree)
                         local res = extractors:extract_from_matched(nodes)
+                        if res.return_statement[1] == "void" then
+                            res.return_statement = nil
+                        end
                         res.identifier = res["_"]
                         return res
                     end,
@@ -56,7 +52,7 @@ return {
             },
         },
         class = {
-            ["class_declaration"] = {
+            ["class_declaration|interface_declaration"] = {
                 ["0"] = {
                     extract = function()
                         return {}

--- a/lua/neogen/templates/xmldoc.lua
+++ b/lua/neogen/templates/xmldoc.lua
@@ -7,7 +7,8 @@ return {
 
     { nil, "/// <summary>", {} },
     { nil, "/// $1", {} },
-    { i.Parameter, '/// <param name="%s">$1</param>', { type = { "func", "type" } } },
-    { i.Return, "/// <returns>$1</returns>", { type = { "func", "type" } } },
     { nil, "/// </summary>", {} },
+    { i.Parameter, '/// <param name="%s">$1</param>', { type = { "func", "type" } } },
+    { i.Tparam, '/// <typeparam name="%s">$1</typeparam>', { type = { "func", "class" } } },
+    { i.Return, "/// <returns>$1</returns>", { type = { "func", "type" } } },
 }


### PR DESCRIPTION
This PR implements type params docs support, interface documentation and fixes issues with the xmldoc generation.

I have never seen doxygen used on a C# project, so I wonder if the default annotation type should be doxygen instead of xmldocs, but I have not changed it (for now).