### PR TITLE
changed luasnip parse call options

### DIFF
--- a/lua/neogen/init.lua
+++ b/lua/neogen/init.lua
@@ -239,7 +239,7 @@ end
 ---@eval return MiniDoc.afterlines_to_code(MiniDoc.current.eval_section)
 ---@text # Changelog~
 ---
---- Note: We will only document `major` and `minor` versions, not `patch` ones.
+--- Note: We will only document `major` and `minor` versions, not `patch` ones. (only X and Y in X.Y.z)
 ---
 --- ## 2.8.0~
 ---   - Specify annotation convention on `generate()` method (see |neogen.generate()|)
@@ -280,7 +280,7 @@ end
 ---     with multiple annotation conventions.
 ---@tag neogen-changelog
 ---@toc_entry Changes in neogen plugin
-neogen.version = "2.8.0"
+neogen.version = "2.8.1"
 --minidoc_afterlines_end
 
 return neogen

--- a/lua/neogen/snippet.lua
+++ b/lua/neogen/snippet.lua
@@ -79,7 +79,8 @@ snippet.engines.luasnip = function(snip, pos)
     local _snip = table.concat(snip, "\n")
 
     ls.snip_expand(
-        ls.s("", ls.parser.parse_snippet(nil, _snip), {
+
+        ls.s("", ls.parser.parse_snippet(nil, _snip,{trim_empty = false, dedent = false}), {
 
             child_ext_opts = {
                 -- for highlighting the placeholders


### PR DESCRIPTION
This pr fixes #108 

In commit c4f7e797376c8e3ab6f848bd6bc5d33019fea5e1 of LuaSnip some default options  to `ls.parser.parse_snippet`  were added.

This options when set to true (the default) perform some cleanup to the snippets by dedenting them and cleaning empty space.

Fixed the issue it by setting them to false.

Also found in the LuaSnip commit changes a reference to the function `lsp_expand` which internally calls ls.parser.parse_snippet() with this options. Maybe we should be calling that function instead?

If you could guide me to a proper solution if this isn't ok i would be glad to help.
