### PR TITLE
Add godoc file template

### DIFF
--- a/lua/neogen/configurations/go.lua
+++ b/lua/neogen/configurations/go.lua
@@ -5,7 +5,8 @@ local nodes_utils = require("neogen.utilities.nodes")
 return {
     parent = {
         func = { "function_declaration", "method_declaration" },
-        type = { "package_clause", "const_declaration", "var_declaration", "type_declaration" },
+        type = { "const_declaration", "var_declaration", "type_declaration" },
+        file = { "package_clause" },
     },
 
     data = {
@@ -45,8 +46,27 @@ return {
                 },
             },
         },
+        file = {
+            ["package_clause"] = {
+                ["0"] = {
+                    extract = function(node)
+                        local tree = {
+                            {
+                                retrieve = "first",
+                                node_type = "package_identifier",
+                                extract = "true",
+                                as = "package_name",
+                            },
+                        }
+                        local nodes = nodes_utils:matching_nodes_from(node, tree)
+                        local res = extractors:extract_from_matched(nodes)
+                        return res
+                    end,
+                },
+            },
+        },
         type = {
-            ["package_clause|const_declaration|var_declaration"] = {
+            ["const_declaration|var_declaration"] = {
                 ["0"] = {
                     extract = function()
                         return {}

--- a/lua/neogen/init.lua
+++ b/lua/neogen/init.lua
@@ -285,7 +285,7 @@ end
 ---     with multiple annotation conventions.
 ---@tag neogen-changelog
 ---@toc_entry Changes in neogen plugin
-neogen.version = "2.10.1"
+neogen.version = "2.10.2"
 --minidoc_afterlines_end
 
 return neogen

--- a/lua/neogen/templates/godoc.lua
+++ b/lua/neogen/templates/godoc.lua
@@ -2,4 +2,5 @@ return {
     { nil, " $1", { no_results = true } },
     { "func_name", " %s $1", { type = { "func" } } },
     { "type_name", " %s $1", { type = { "type" } } },
+    { "package_name", " Package %s $1", { type = { "file" } } },
 }


### PR DESCRIPTION
According to https://go.dev/doc/comment, the package clause should use complete sentences. 

The `Package [package-identifier] ..." format is correct according to https://staticcheck.io/docs/checks/#ST1000