### PR TITLE
Fix parameters in python docstrings

### DIFF
--- a/lua/neogen/configurations/python.lua
+++ b/lua/neogen/configurations/python.lua
@@ -50,7 +50,7 @@ return {
                                         retrieve = "all",
                                         node_type = "typed_default_parameter",
                                         as = i.Tparam,
-                                        extract = true
+                                        extract = true,
                                     },
                                     {
                                         retrieve = "first",
@@ -127,7 +127,7 @@ return {
 
                         -- Check if the function is inside a class
                         -- If so, remove reference to the first parameter (that can be `self`, `cls`, or a custom name)
-                        if res.identifier and locator({ current = node }, parent.class) then
+                        if res.parameters and locator({ current = node }, parent.class) then
                             local remove_identifier = true
                             -- Check if function is a static method. If so, will not remove the first parameter
                             if node:parent():type() == "decorated_definition" then
@@ -138,9 +138,9 @@ return {
                                 end
                             end
                             if remove_identifier then
-                                table.remove(res.identifier, 1)
-                                if vim.tbl_isempty(res.identifier) then
-                                    res.identifier = nil
+                                table.remove(res.parameters, 1)
+                                if vim.tbl_isempty(res.parameters) then
+                                    res.parameters = nil
                                 end
                             end
                         end

--- a/lua/neogen/configurations/python.lua
+++ b/lua/neogen/configurations/python.lua
@@ -127,7 +127,7 @@ return {
 
                         -- Check if the function is inside a class
                         -- If so, remove reference to the first parameter (that can be `self`, `cls`, or a custom name)
-                        if res.parameters and locator({ current = node }, parent.class) then
+                        if res[i.Parameter] and locator({ current = node }, parent.class) then
                             local remove_identifier = true
                             -- Check if function is a static method. If so, will not remove the first parameter
                             if node:parent():type() == "decorated_definition" then
@@ -138,9 +138,9 @@ return {
                                 end
                             end
                             if remove_identifier then
-                                table.remove(res.parameters, 1)
-                                if vim.tbl_isempty(res.parameters) then
-                                    res.parameters = nil
+                                table.remove(res[i.Parameter], 1)
+                                if vim.tbl_isempty(res[i.Parameter]) then
+                                    res[i.Parameter] = nil
                                 end
                             end
                         end

--- a/lua/neogen/configurations/python.lua
+++ b/lua/neogen/configurations/python.lua
@@ -85,6 +85,7 @@ return {
                                             {
                                                 retrieve = "first",
                                                 node_type = "identifier",
+                                                recursive = true,
                                                 extract = true,
                                                 as = i.Throw,
                                             },

--- a/lua/neogen/init.lua
+++ b/lua/neogen/init.lua
@@ -241,6 +241,9 @@ end
 ---
 --- Note: We will only document `major` and `minor` versions, not `patch` ones. (only X and Y in X.Y.z)
 ---
+--- ## 2.13.0~
+---   - Improve google docstrings template (#124)
+---   - Fix minor python retriever issues (#124)
 --- ## 2.12.0~
 ---   - Fetch singleton methods in ruby (#121)
 --- ## 2.11.0~
@@ -292,7 +295,7 @@ end
 ---     with multiple annotation conventions.
 ---@tag neogen-changelog
 ---@toc_entry Changes in neogen plugin
-neogen.version = "2.12.0"
+neogen.version = "2.13.0"
 --minidoc_afterlines_end
 
 return neogen

--- a/lua/neogen/templates/google_docstrings.lua
+++ b/lua/neogen/templates/google_docstrings.lua
@@ -14,7 +14,7 @@ return {
     { i.HasParameter, "", { type = { "func" } } },
     { i.HasParameter, "Args:", { type = { "func" } } },
     { i.Parameter, "    %s ($1): $1", { type = { "func" } } },
-    { { i.Parameter, i.Type }, "    %s (%s): $1", { required = i.Tparam, type = { "func" } } },
+    { { i.Parameter, i.Type }, "    %s: $1", { required = i.Tparam, type = { "func" } } },
     { i.ArbitraryArgs, "    %s: $1", { type = { "func" } } },
     { i.Kwargs, "    %s: $1", { type = { "func" } } },
     { i.ClassAttribute, "    %s: $1", { before_first_item = { "", "Attributes: " } } },


### PR DESCRIPTION
Hi there! Thanks for this great extension.

This small PR fixes a few select issues I noticed with Python parameters. Please forgive any silly errors and let me know if there's anything else I can do.

Thanks!


1. **Allow `raise_statement`s like `raise Exception('Some message')` to trigger the exception raising behavior.** Instantiating an exception buries the `identifier` inside of a function call, so such `raise_statement`s aren't extracted unless recursion is allowed.
2. **Remove `self`/`cls` parameter when a function is in a class.** This functionality already existed, but the former code checked for the existence of `res.identifier` (the name of the function), which was never extracted.
3. **For `google_docstrings`: Don't include types in docstring for parameter that have a type hint.** This brings `google_docstrings` in line with the current guideline: ["The description should include required type(s) if the code does not contain a corresponding type annotation."](https://google.github.io/styleguide/pyguide.html#doc-function-args)