### PR TITLE
JSDoc and TSDoc should always start with two asterisks

### DIFF
--- a/lua/neogen/templates/jsdoc.lua
+++ b/lua/neogen/templates/jsdoc.lua
@@ -1,8 +1,8 @@
 local i = require("neogen.types.template").item
 
 return {
-    { nil, "/* $1 */", { no_results = true, type = { "func", "class" } } },
-    { nil, "/* @type $1 */", { no_results = true, type = { "type" } } },
+    { nil, "/** $1 */", { no_results = true, type = { "func", "class" } } },
+    { nil, "/** @type $1 */", { no_results = true, type = { "type" } } },
 
     { nil, "/**", { no_results = true, type = { "file" } } },
     { nil, " * @module $1", { no_results = true, type = { "file" } } },

--- a/lua/neogen/templates/tsdoc.lua
+++ b/lua/neogen/templates/tsdoc.lua
@@ -1,8 +1,8 @@
 local i = require("neogen.types.template").item
 
 return {
-    { nil, "/* $1 */", { no_results = true, type = { "func", "class" } } },
-    { nil, "/* @type $1 */", { no_results = true, type = { "type" } } },
+    { nil, "/** $1 */", { no_results = true, type = { "func", "class" } } },
+    { nil, "/** @type $1 */", { no_results = true, type = { "type" } } },
 
     { nil, "/**", { no_results = true, type = { "file" } } },
     { nil, " * @module $1", { no_results = true, type = { "file" } } },


### PR DESCRIPTION
## JSDoc

According to the JSDoc documentation, each comment must start with a `/**` sequence.

[Use JSDoc: Getting Started with JSDoc 3](https://jsdoc.app/about-getting-started.html#adding-documentation-comments-to-your-code)

> Each comment must start with a /\*\* sequence in order to be recognized by the JSDoc parser. Comments beginning with /\*, /\*\*\*, or more than 3 stars will be ignored.

## TSDoc

Although it is not documented, TSDoc always expects comments to start with `/**`.

[microsoft/tsdoc/tsdoc/src/parser/LineExtractor.ts](https://github.com/microsoft/tsdoc/blob/d8ce4aedcf64b5c948e7152ba02ac6c7bdedc9be/tsdoc/src/parser/LineExtractor.ts#L84)

> `'Expecting a leading "/**"'`