### PR TITLE
Inner functions do not strip their first parameter

### DIFF
--- a/lua/neogen/configurations/python.lua
+++ b/lua/neogen/configurations/python.lua
@@ -204,7 +204,10 @@ return {
                                 if decorator == "@staticmethod" then
                                     remove_identifier = false
                                 end
+                            elseif node:parent():parent():type() == "function_definition" then
+                                remove_identifier = false
                             end
+
                             if remove_identifier then
                                 table.remove(res[i.Parameter], 1)
                                 if vim.tbl_isempty(res[i.Parameter]) then

--- a/lua/neogen/init.lua
+++ b/lua/neogen/init.lua
@@ -299,7 +299,7 @@ end
 ---     with multiple annotation conventions.
 ---@tag neogen-changelog
 ---@toc_entry Changes in neogen plugin
-neogen.version = "2.15.1"
+neogen.version = "2.15.2"
 --minidoc_afterlines_end
 
 return neogen


### PR DESCRIPTION
Closes: https://github.com/danymat/neogen/issues/150

Given a class with nested functions such as the one below

```python
class Thing(object):
    def foo(self, bar, fizz, buzz):
        def another(inner, function):
            def inner_most(more, stuff):
                pass
```

Where `Thing.foo` requires parameter stripping in its generated docstrings but `another` and `inner_most` are free functions whose parameters should not strip. This PR accounts for both cases. See "Before (This PR)" and "After (This PR's Fix)", below


### Before (This PR)
https://github.com/danymat/neogen/assets/10103049/b1b77e43-07b3-4e8f-b7b3-d290d0f5501a

### After (This PR's Fix)
https://github.com/danymat/neogen/assets/10103049/9be32a0e-995c-4c67-aa69-97c7544bc487

## Note
I was a bit worried calling `node:parent():parent():type()` in case somehow node:parent():parent() returns nil, in which case the call to type() would fail. But because that code is only called when the function has `parent.class`, I think this should never be a problem as there will always be at least 2 parents (class_definition and then module). Seemed safe to me