### PR TITLE
Remove usage of nvim-treesitter utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 ## Requirements
 
-- Install [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
+Have Tree-sitter parsers installed on your system. For more information, check out the [:treesitter-parsers](https://neovim.io/doc/user/treesitter.html#treesitter-parsers) neovim help page.
 
 ## Installation
 
@@ -43,7 +43,6 @@ Use your favorite package manager to install Neogen, e.g:
 ```lua
 { 
     "danymat/neogen", 
-    dependencies = "nvim-treesitter/nvim-treesitter", 
     config = true,
     -- Uncomment next line if you want to follow only stable versions
     -- version = "*" 
@@ -58,7 +57,6 @@ use {
     config = function()
         require('neogen').setup {}
     end,
-    requires = "nvim-treesitter/nvim-treesitter",
     -- Uncomment next line if you want to follow only stable versions
     -- tag = "*"
 }

--- a/docs/advanced-integration.md
+++ b/docs/advanced-integration.md
@@ -4,6 +4,8 @@
 
 The configuration file for a language is in `lua/configurations/{lang}.lua`.
 
+_Note: Be aware that Neogen uses Treesitter to operate. You can install [TSPlayground](https://github.com/nvim-treesitter/playground) to check the AST._
+
 Below is a commented sample of the configuration file for `lua`.
 
 ```lua

--- a/docs/advanced-integration.md
+++ b/docs/advanced-integration.md
@@ -2,16 +2,14 @@
 
 ## Configuration file
 
-The configuration file for a language is in `lua/configurations/{lang}.lua`. 
-
-_Note: Be aware that Neogen uses Treesitter to operate. You can install [TSPlayground](https://github.com/nvim-treesitter/playground) to check the AST._
+The configuration file for a language is in `lua/configurations/{lang}.lua`.
 
 Below is a commented sample of the configuration file for `lua`.
 
 ```lua
 -- Search for these nodes
 parent = { "function", "local_function", "local_variable_declaration", "field", "variable_declaration" },
-                                                                                                          
+
 -- Traverse down these nodes and extract the information as necessary
 data = {
     -- If function or local_function is found as a parent
@@ -20,12 +18,12 @@ data = {
         ["2"] = {
             -- This second child has to be of type "parameters", otherwise does nothing
             match = "parameters",
-                                                                                       
+
 	    -- Extractor function that returns a set of TSname = values with values being of type string[]
             extract = function(node)
                 local regular_params = neogen.utilities.extractors:extract_children_text("identifier")(node)
                 local varargs = neogen.utilities.extractors:extract_children_text("spread")(node)
-                                                                                                          
+
                 return {
                     parameters = regular_params,
                     vararg = varargs,
@@ -34,15 +32,15 @@ data = {
         },
     },
 },
-                                                                                                          
+
 -- Custom lua locator that escapes from comments (More on locators below)
 -- Passing nil will use the default locator
 locator = require("neogen.locators.lua"),
-                                                                                                          
+
 -- Use default granulator and generator (More on them below)
 granulator = nil,
 generator = nil,
-                                                            
+
 -- Template to use with the generator. (More on this below)
 template = {
     -- Which annotation convention to use
@@ -127,7 +125,7 @@ data = {
 
 Notes:
 
-- If you create your own granulator, you can add any kind of parameters in the `data` field from configuration file as long as the function signature is the same provided. 
+- If you create your own granulator, you can add any kind of parameters in the `data` field from configuration file as long as the function signature is the same provided.
 - Utilities are provided. You can check out their documentation in `lua/utilities/`.
 
 ## Generators
@@ -145,6 +143,6 @@ end
 - `parent` is the parent node found with the locator
 - `data` is the result from the granulator
 - `template` being the `template` field from the language configuration file.
-- `start_row` is the row in which we will append `generated_template` 
+- `start_row` is the row in which we will append `generated_template`
 - `start_col` is the col in which the `generated_template` will start
 - `generated_template` is the output we will append on the specified locations.

--- a/lua/neogen/generator.lua
+++ b/lua/neogen/generator.lua
@@ -1,13 +1,6 @@
 local helpers = require("neogen.utilities.helpers")
 local notify = helpers.notify
 
-local ok, ts_utils = pcall(require, "nvim-treesitter.ts_utils")
-if not ok then
-    notify("neogen requires nvim-treesitter to operate :(", vim.log.levels.ERROR)
-    return function(_, _) end
-end
-local ts_parsers = require("nvim-treesitter.parsers")
-
 local conf = require("neogen.config").get()
 local granulator = require("neogen.granulator")
 
@@ -65,11 +58,11 @@ end
 
 -- Get nearest parent node
 local function get_parent_node(filetype, node_type, language)
-    local parser_name = ts_parsers.ft_to_lang(filetype)
+    local parser_name = vim.treesitter.language.get_lang(filetype)
     local parser = vim.treesitter.get_parser(0, parser_name)
     local tstree = parser:parse()[1]
     local tree = tstree:root()
-    local current_node = ts_utils.get_node_at_cursor(0)
+    local current_node = vim.treesitter.get_node()
     local match_any = node_type == ANY_TYPE
     local target_node, target_type
     local locator = language.locator or default_locator

--- a/lua/neogen/granulator.lua
+++ b/lua/neogen/granulator.lua
@@ -1,7 +1,7 @@
 local helpers = require("neogen.utilities.helpers")
 
 --- Tries to use the configuration to find all required content nodes from the parent node
----@param parent_node userdata the node found by the locator
+---@param parent_node TSNode the node found by the locator
 ---@param node_data table the data from configurations[lang].data
 return function(parent_node, node_data)
     local result = {}

--- a/lua/neogen/init.lua
+++ b/lua/neogen/init.lua
@@ -299,7 +299,7 @@ end
 ---     with multiple annotation conventions.
 ---@tag neogen-changelog
 ---@toc_entry Changes in neogen plugin
-neogen.version = "2.15.2"
+neogen.version = "2.15.3"
 --minidoc_afterlines_end
 
 return neogen

--- a/lua/neogen/locators/default.lua
+++ b/lua/neogen/locators/default.lua
@@ -1,12 +1,12 @@
 ---@class Neogen.node_info
----@field current userdata the current node from cursor
----@field root? userdata the root node
+---@field current TSNode the current node from cursor
+---@field root? TSNode the root node
 
 --- The default locator tries to find one of the nodes to match in the current node
 --- If it does not find one, will fetch the parents until he finds one
 ---@param node_info Neogen.node_info a node informations
----@param nodes_to_match table a list of parent nodes to match
----@return userdata node one of the nodes to match directly above the given node
+---@param nodes_to_match TSNode[] a list of parent nodes to match
+---@return TSNode? node one of the nodes to match directly above the given node
 return function(node_info, nodes_to_match)
     if not node_info.current then
         if vim.tbl_contains(nodes_to_match, node_info.root:type()) then

--- a/lua/neogen/locators/lua.lua
+++ b/lua/neogen/locators/lua.lua
@@ -1,4 +1,3 @@
-local ts_utils = require("nvim-treesitter.ts_utils")
 local default_locator = require("neogen.locators.default")
 
 return function(node_info, nodes_to_match)
@@ -6,7 +5,7 @@ return function(node_info, nodes_to_match)
     if node_info.current and node_info.current:type() == "source" then
         local start_row, _, _, _ = vim.treesitter.get_node_range(node_info.current)
         vim.api.nvim_win_set_cursor(0, { start_row + 1, 0 })
-        node_info.current = ts_utils.get_node_at_cursor()
+        node_info.current = vim.treesitter.get_node()
     end
 
     local found_node = default_locator(node_info, nodes_to_match)

--- a/lua/neogen/locators/typescript.lua
+++ b/lua/neogen/locators/typescript.lua
@@ -1,5 +1,8 @@
 local default_locator = require("neogen.locators.default")
 
+---@param node_info Neogen.node_info
+---@param nodes_to_match TSNode[]
+---@return TSNode?
 return function(node_info, nodes_to_match)
     local found_node = default_locator(node_info, nodes_to_match)
 

--- a/lua/neogen/utilities/helpers.lua
+++ b/lua/neogen/utilities/helpers.lua
@@ -20,13 +20,17 @@ return {
         return vim.tbl_keys(language.parent)
     end,
 
+    ---@param s string
+    ---@param sep string
+    ---@param plain boolean
+    ---@return string[]
     split = function(s, sep, plain)
         return vim.fn.has("nvim-0.6") == 1 and vim.split(s, sep, { plain = plain }) or vim.split(s, sep, plain)
     end,
 
     --- Gets the text from the node
     ---@private
-    ---@param node userdata node to fetch text from
+    ---@param node TSNode node to fetch text from
     ---@param bufnr? number originated buffer number. Defaults to 0
     ---@return table newline separated list of text
     get_node_text = function(node, bufnr)

--- a/lua/neogen/utilities/nodes.lua
+++ b/lua/neogen/utilities/nodes.lua
@@ -2,7 +2,7 @@ local helpers = require("neogen.utilities.helpers")
 return {
     --- Get a list of child nodes that match the provided node name
     --- @param _ any
-    --- @param parent userdata the parent's node
+    --- @param parent TSNode the parent's node
     --- @param node_type? string the node type to search for (if multiple childrens, separate each one with "|")
     --- @return table a table of nodes that matched the name
     matching_child_nodes = function(_, parent, node_type)
@@ -27,7 +27,7 @@ return {
     end,
 
     --- Find all nested childs from `parent` that match `node_name`. Returns a table of found nodes
-    --- @param parent userdata
+    --- @param parent TSNode
     --- @param node_name string
     --- @param opts table
     ---   - opts.first (bool):      if true, breaks at the first recursive item
@@ -53,7 +53,7 @@ return {
     end,
 
     --- Get all required nodes from tree
-    --- @param parent userdata the parent node
+    --- @param parent TSNode the parent node
     --- @param tree table a nested table : { retrieve = "all|first", node_type = node_name, subtree = tree, recursive = true }
     --- If you want to extract the node, do not specify the subtree and instead: extract = true
     --- Optional: you can specify position = number instead of retrieve, and it will fetch the child node at position number


### PR DESCRIPTION
This will be deprecated soon and `vim.treesitter` should be used instead where applicable

Thanks!