### PR TITLE
fix: no surrounding spaces for one-line-docstring

### DIFF
--- a/lua/neogen/templates/google_docstrings.lua
+++ b/lua/neogen/templates/google_docstrings.lua
@@ -1,7 +1,7 @@
 local i = require("neogen.types.template").item
 
 return {
-    { nil, '""" $1 """', { no_results = true, type = { "class", "func" } } },
+    { nil, '"""$1"""', { no_results = true, type = { "class", "func" } } },
     { nil, '"""$1', { no_results = true, type = { "file" } } },
     { nil, "", { no_results = true, type = { "file" } } },
     { nil, "$1", { no_results = true, type = { "file" } } },

--- a/lua/neogen/templates/numpydoc.lua
+++ b/lua/neogen/templates/numpydoc.lua
@@ -1,7 +1,7 @@
 local i = require("neogen.types.template").item
 
 return {
-    { nil, '""" $1 """', { no_results = true, type = { "class", "func" } } },
+    { nil, '"""$1"""', { no_results = true, type = { "class", "func" } } },
     { nil, '"""$1', { no_results = true, type = { "file" } } },
     { nil, "", { no_results = true, type = { "file" } } },
     { nil, "$1", { no_results = true, type = { "file" } } },

--- a/lua/neogen/templates/reST.lua
+++ b/lua/neogen/templates/reST.lua
@@ -1,7 +1,7 @@
 local i = require("neogen.types.template").item
 
 return {
-    { nil, '""" $1 """', { no_results = true, type = { "class", "func" } } },
+    { nil, '"""$1"""', { no_results = true, type = { "class", "func" } } },
     { nil, '"""$1', { no_results = true, type = { "file" } } },
     { nil, "", { no_results = true, type = { "file" } } },
     { nil, "$1", { no_results = true, type = { "file" } } },


### PR DESCRIPTION
According to [pydocstyle rule D210](https://www.pydocstyle.org/en/6.3.0/error_codes.html) and [pep257](https://peps.python.org/pep-0257/#one-line-docstrings), there should not be any whitespace surrounding one-line docstrings. 

This PR removes those for all three python-docstring-templates