### PR TITLE
Bug fix - Python returns now respect nested functions

### DIFF
--- a/lua/neogen/configurations/python.lua
+++ b/lua/neogen/configurations/python.lua
@@ -268,27 +268,27 @@ return {
                         end
 
                         local results = helpers.copy({
-                                [i.HasParameter] = function(t)
-                                    return (t[i.Parameter] or t[i.Tparam]) and { true }
-                                end,
-                                [i.HasReturn] = function(t)
-                                    return (t[i.ReturnTypeHint] or t[i.Return]) and { true }
-                                end,
-                                [i.HasThrow] = function(t)
-                                    return t[i.Throw] and { true }
-                                end,
-                                [i.Type] = true,
-                                [i.Parameter] = true,
-                                [i.Return] = true,
-                                [i.ReturnTypeHint] = true,
-                                [i.HasYield] = function(t)
-                                    return t[i.Yield] and { true }
-                                end,
-                                [i.ArbitraryArgs] = true,
-                                [i.Kwargs] = true,
-                                [i.Throw] = true,
-                                [i.Tparam] = true,
-                            }, res) or {}
+                            [i.HasParameter] = function(t)
+                                return (t[i.Parameter] or t[i.Tparam]) and { true }
+                            end,
+                            [i.HasReturn] = function(t)
+                                return (t[i.ReturnTypeHint] or t[i.Return]) and { true }
+                            end,
+                            [i.HasThrow] = function(t)
+                                return t[i.Throw] and { true }
+                            end,
+                            [i.Type] = true,
+                            [i.Parameter] = true,
+                            [i.Return] = true,
+                            [i.ReturnTypeHint] = true,
+                            [i.HasYield] = function(t)
+                                return t[i.Yield] and { true }
+                            end,
+                            [i.ArbitraryArgs] = true,
+                            [i.Kwargs] = true,
+                            [i.Throw] = true,
+                            [i.Tparam] = true,
+                        }, res) or {}
 
                         -- Removes generation for returns that are not typed
                         if results[i.ReturnTypeHint] then

--- a/lua/neogen/init.lua
+++ b/lua/neogen/init.lua
@@ -299,7 +299,7 @@ end
 ---     with multiple annotation conventions.
 ---@tag neogen-changelog
 ---@toc_entry Changes in neogen plugin
-neogen.version = "2.15.2"
+neogen.version = "2.15.3"
 --minidoc_afterlines_end
 
 return neogen

--- a/lua/neogen/init.lua
+++ b/lua/neogen/init.lua
@@ -301,7 +301,7 @@ end
 ---     with multiple annotation conventions.
 ---@tag neogen-changelog
 ---@toc_entry Changes in neogen plugin
-neogen.version = "2.16.0"
+neogen.version = "2.16.1"
 --minidoc_afterlines_end
 
 return neogen


### PR DESCRIPTION
Neogen's Python implementation has a bug for return nodes. Return statements are matched recursively, like so

```lua
{
    retrieve = "all",
    node_type = "return_statement",
    recursive = true,
    extract = true,
    as = i.Return,
},
```

But when you have a function-within-a-function, this crosses the nested function_definition boundary, even if the outer function has no return.

I couldn't figure out if there's a way to get the `tree` expression to "stop recursing on first function_definition" so, instead of trying to solve it in the tree, I added a clean-up step called `validate_direct_returns`.

I also made some (completely unrelated) clean-up edits to `validate_bare_returns`. If you'd like, I can split that work into a separate branch + PR

### Before
https://github.com/danymat/neogen/assets/10103049/a3198b7e-7876-41cb-9068-6f669eca5cf7

### After
https://github.com/danymat/neogen/assets/10103049/f4b37dce-1825-43d4-a2b4-561787993cb5