### PR TITLE
fix: functions with only bare returns now evaluate properly

### DIFF
--- a/lua/neogen/configurations/python.lua
+++ b/lua/neogen/configurations/python.lua
@@ -247,8 +247,8 @@ return {
                         end
 
                         if nodes[i.Return] then
-                            validate_bare_returns(nodes)
                             validate_direct_returns(nodes, node)
+                            validate_bare_returns(nodes)
                         end
 
                         validate_yield_nodes(nodes)


### PR DESCRIPTION
**Error**: 

Only bare return functions override the value for nodes[i.Return], and because validate_direct_returns evaluated after, it broke on line 80, expecting a table but getting a nil value

_Example code_

```
def foo(bar=None):
    if not bar:
        return
    else:
        print(bar)
```

Throws this error:
```
E5108: Error executing lua ...dez/personal/neogen/lua/neogen/configurations/python.lua:80: bad argument #1 to 'pairs' (table expected, got nil)                                                                    
stack traceback:                                                                                                                                                                                                   
        [C]: in function 'pairs'                                                                                                                                                                                   
        ...dez/personal/neogen/lua/neogen/configurations/python.lua:80: in function 'validate_direct_returns'                                                                                                      
        ...dez/personal/neogen/lua/neogen/configurations/python.lua:251: in function 'extract'                                                                                                                     
        .../andres.mendez/personal/neogen/lua/neogen/granulator.lua:34: in function 'granulator'                                                                                                                   
        ...e/andres.mendez/personal/neogen/lua/neogen/generator.lua:280: in function 'generate'                                                                                                                    
        [string ":lua"]:1: in main chunk
```


