### PR TITLE
Fixed Python bugs + added unittests

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,13 @@ Tip: Take a look at this beatiful diagram, showing a representation of the codeb
     
 ![Visualization of this repo](./diagram.svg)
 
+## Tests
+Run tests using this command
+
+```sh
+make test
+```
+
 ## GIFS
 
 ![screen1](https://user-images.githubusercontent.com/5306901/135055052-6ee6a5e8-3f30-4c41-872e-e624e21a1e98.gif)

--- a/lua/neogen/configurations/python.lua
+++ b/lua/neogen/configurations/python.lua
@@ -38,6 +38,30 @@ local get_nearest_parent = function(node, type_name)
 end
 
 
+--- Remove raise (aka throw) nodes so there is only one node per-type.
+---
+---@param nodes table<string, TSNode[]> The nodes to simplify / reduce.
+local deduplicate_throw_nodes = function(nodes)
+    if not nodes[i.Throw] then
+        return
+    end
+
+    local output = {}
+
+    local seen = {}
+
+    for _, node in ipairs(nodes[i.Throw]) do
+        local text = helpers.get_node_text(node)[1]
+
+        if not vim.tbl_contains(seen, text) then
+            table.insert(seen, text)
+            table.insert(output, node)
+        end
+    end
+
+    nodes[i.Throw] = output
+end
+
 --- Modify `nodes` if the found return(s) are **all** bare-returns.
 ---
 --- A bare-return is used to return early from a function and aren't meant to be
@@ -253,6 +277,8 @@ return {
 
                         validate_yield_nodes(nodes)
 
+                        deduplicate_throw_nodes(nodes)
+
                         local res = extractors:extract_from_matched(nodes)
                         res[i.Tparam] = temp[i.Tparam]
 
@@ -292,7 +318,7 @@ return {
                                 return (t[i.Parameter] or t[i.Tparam]) and { true }
                             end,
                             [i.HasReturn] = function(t)
-                                return (t[i.ReturnTypeHint] or t[i.Return]) and { true }
+                                return (not t[i.Yield] and (t[i.ReturnTypeHint] or t[i.Return]) and { true })
                             end,
                             [i.HasThrow] = function(t)
                                 return t[i.Throw] and { true }

--- a/lua/neogen/init.lua
+++ b/lua/neogen/init.lua
@@ -309,7 +309,7 @@ end
 ---     with multiple annotation conventions.
 ---@tag neogen-changelog
 ---@toc_entry Changes in neogen plugin
-neogen.version = "2.19.0"
+neogen.version = "2.19.1"
 --minidoc_afterlines_end
 
 return neogen

--- a/tests/neogen/python_google_spec.lua
+++ b/tests/neogen/python_google_spec.lua
@@ -460,43 +460,42 @@ describe("python: google_docstrings", function()
             assert.equal(expected, result)
         end)
 
-        -- TODO: This is broken. Fix it!
-        -- This used to work but broke later on, it seems - https://github.com/danymat/neogen/pull/142
-        -- it("lists only one entry per-raised type", function()
-        --     local source = [[
-        --     def foo(bar):|cursor|
-        --         if bar:
-        --             raise TypeError("THING")
-        --
-        --         if GLOBAL:
-        --             raise ValueError("asdffsd")
-        --
-        --         raise TypeError("BLAH")
-        --     ]]
-        --
-        --     local expected = [[
-        --     def foo(bar):
-        --         """[TODO:description]
-        --
-        --         Args:
-        --             bar ([TODO:parameter]): [TODO:description]
-        --
-        --         Raises:
-        --             TypeError: [TODO:throw]
-        --             ValueError: [TODO:throw]
-        --         """
-        --         if bar:
-        --             raise TypeError("THING")
-        --
-        --             raise ValueError("asdffsd")
-        --
-        --         raise TypeError("BLAH")
-        --     ]]
-        --
-        --     local result = _make_python_docstring(source)
-        --
-        --     assert.equal(expected, result)
-        -- end)
+        it("lists only one entry per-raised type", function()
+            local source = [[
+            def foo(bar):|cursor|
+                if bar:
+                    raise TypeError("THING")
+
+                if GLOBAL:
+                    raise ValueError("asdffsd")
+
+                raise TypeError("BLAH")
+            ]]
+
+            local expected = [[
+            def foo(bar):
+                """[TODO:description]
+
+                Args:
+                    bar ([TODO:parameter]): [TODO:description]
+
+                Raises:
+                    TypeError: [TODO:throw]
+                    ValueError: [TODO:throw]
+                """
+                if bar:
+                    raise TypeError("THING")
+
+                if GLOBAL:
+                    raise ValueError("asdffsd")
+
+                raise TypeError("BLAH")
+            ]]
+
+            local result = make_google_docstrings(source)
+
+            assert.equal(expected, result)
+        end)
 
         it("works with modules, even if they are nested", function()
             local source = [[
@@ -540,43 +539,41 @@ describe("python: google_docstrings", function()
             assert.equal(expected, result)
         end)
 
-        -- TODO: This is broken. Fix it!
-        -- This used to work but broke later on, it seems - https://github.com/danymat/neogen/pull/142
-        -- it("works with 2+ raises", function()
-        --     local source = [[
-        --     def foo(bar):|cursor|
-        --         if bar:
-        --             raise TypeError("THING")
-        --
-        --         if GLOBAL:
-        --             raise TypeError("asdffsd")
-        --
-        --         raise TypeError("BLAH")
-        --     ]]
-        --
-        --     local expected = [[
-        --     def foo(bar):
-        --         """[TODO:description]
-        --
-        --         Args:
-        --             bar ([TODO:parameter]): [TODO:description]
-        --
-        --         Raises:
-        --             TypeError: [TODO:throw]
-        --         """
-        --         if bar:
-        --             raise TypeError("THING")
-        --
-        --         if GLOBAL:
-        --             raise TypeError("asdffsd")
-        --
-        --         raise TypeError("BLAH")
-        --     ]]
-        --
-        --     local result = _make_python_docstring(source)
-        --
-        --     assert.equal(expected, result)
-        -- end)
+        it("works with 2+ raises", function()
+            local source = [[
+            def foo(bar):|cursor|
+                if bar:
+                    raise TypeError("THING")
+
+                if GLOBAL:
+                    raise TypeError("asdffsd")
+
+                raise TypeError("BLAH")
+            ]]
+
+            local expected = [[
+            def foo(bar):
+                """[TODO:description]
+
+                Args:
+                    bar ([TODO:parameter]): [TODO:description]
+
+                Raises:
+                    TypeError: [TODO:throw]
+                """
+                if bar:
+                    raise TypeError("THING")
+
+                if GLOBAL:
+                    raise TypeError("asdffsd")
+
+                raise TypeError("BLAH")
+            ]]
+
+            local result = make_google_docstrings(source)
+
+            assert.equal(expected, result)
+        end)
     end)
 
     describe("func - returns", function()
@@ -738,6 +735,27 @@ describe("python: google_docstrings", function()
                 yield
             except:
                 print("bad thing happened")
+        ]]
+
+            local result = make_google_docstrings(source)
+
+            assert.equal(expected, result)
+        end)
+
+        it("works with type-hints as expected", function()
+            local source = [[
+        def foo() -> typing.Generator[str]:|cursor|
+            yield "asdfsfd"
+        ]]
+
+            local expected = [[
+        def foo() -> typing.Generator[str]:
+            """[TODO:description]
+
+            Yields:
+                [TODO:description]
+            """
+            yield "asdfsfd"
         ]]
 
             local result = make_google_docstrings(source)


### PR DESCRIPTION
addresses: https://github.com/danymat/neogen/issues/188

- Adds a section in the README.md on how to run unittests
- Python Exceptions are now grouped by type (previously it would list each duplicate)
- A function with `yield` should never include `Returns:` (it was accidentally doing this because of type-hints)

## What this PR does not include
(From the original issue)
- [ ] typed *args / **kwargs not generating as expected

I don't know how to fix that one easily. It's still messed up.