### PR TITLE
Python - Fixed nested return + yield call

### DIFF
--- a/lua/neogen/configurations/python.lua
+++ b/lua/neogen/configurations/python.lua
@@ -248,6 +248,9 @@ return {
 
                         if nodes[i.Return] then
                             validate_direct_returns(nodes, node)
+                        end
+
+                        if nodes[i.Return] then
                             validate_bare_returns(nodes)
                         end
 

--- a/lua/neogen/init.lua
+++ b/lua/neogen/init.lua
@@ -309,7 +309,7 @@ end
 ---     with multiple annotation conventions.
 ---@tag neogen-changelog
 ---@toc_entry Changes in neogen plugin
-neogen.version = "2.19.1"
+neogen.version = "2.19.2"
 --minidoc_afterlines_end
 
 return neogen

--- a/tests/neogen/python_google_spec.lua
+++ b/tests/neogen/python_google_spec.lua
@@ -110,6 +110,38 @@ describe("python: google_docstrings", function()
             assert.equal(expected, result)
         end)
 
+        it("works with methods + nested function + return", function()
+            local source = [[
+        def foo():|cursor|
+            def bar():|cursor|
+                return "blah"
+
+            yield "asdfsfd"
+        ]]
+
+            local expected = [[
+        def foo():
+            """[TODO:description]
+
+            Yields:
+                [TODO:description]
+            """
+            def bar():
+                """[TODO:description]
+
+                Returns:
+                    [TODO:return]
+                """
+                return "blah"
+
+            yield "asdfsfd"
+        ]]
+
+            local result = make_google_docstrings(source)
+
+            assert.equal(expected, result)
+        end)
+
         it("works with methods + nested functions", function()
             local source = [[
         # Reference: https://github.com/danymat/neogen/pull/151


### PR DESCRIPTION
The `validate_direct_returns` function can set `nodes[i.Return]` to `nil`. When that happens, `validate_bare_returns` fails. This PR fixes that + adds a unittest to make sure it doesn't come back.