### PR TITLE
docs: mark `opts` parameter as optional in `generate` function

### DIFF
--- a/lua/neogen/init.lua
+++ b/lua/neogen/init.lua
@@ -147,7 +147,7 @@ neogen.configuration = {
 --- For example, if you are inside a function, and called `generate({ type = "func" })`,
 --- Neogen will go until the start of the function and start annotating for you.
 ---
----@param opts table Optional configs to change default behaviour of generation.
+---@param opts? table Optional configs to change default behaviour of generation.
 ---  - {opts.type} `(string, default: "any")` Which type we are trying to use for generating annotations.
 ---    Currently supported: `any`, `func`, `class`, `type`, `file`
 ---  - {opts.annotation_convention} `(table)` convention to use for generating annotations.


### PR DESCRIPTION
Update the LuaLS/EmmyLua annotation for the `generate` function to explicitly mark the `opts` parameter as optional. 

This change aligns the documentation with the existing implementation and resolves language server warnings when calling the function without arguments.