### PR TITLE
Added snippet_engine parameter

### DIFF
--- a/doc/neogen.txt
+++ b/doc/neogen.txt
@@ -182,12 +182,14 @@ Feel free to submit a PR, I will be happy to help you !
 We use semantic versioning ! (https://semver.org)
 Here is the current Neogen version:
 >lua
-  neogen.version = "2.19.4"
+  neogen.version = "2.20.0"
 <
 # Changelog~
 
 Note: We will only document `major` and `minor` versions, not `patch` ones. (only X and Y in X.Y.z)
 
+## 2.20.0~
+   - Add the `snippet_engine` parameter to `neogen.generator` (#202)
 ## 2.19.0~
    - Add support for julia (`julia`) ! (#185)
 ## 2.18.0~

--- a/lua/neogen/generator.lua
+++ b/lua/neogen/generator.lua
@@ -235,7 +235,7 @@ local function generate_content(parent, data, template, required_type, annotatio
 end
 
 return setmetatable({}, {
-    __call = function(_, filetype, node_type, return_snippet, annotation_convention)
+    __call = function(_, filetype, node_type, return_snippet, annotation_convention, snippet_engine)
         if filetype == "" then
             notify("No filetype detected", vim.log.levels.WARN)
             return
@@ -319,7 +319,7 @@ return setmetatable({}, {
             return generated_snippet, row
         end
 
-        local snippet_engine = conf.snippet_engine
+        snippet_engine = snippet_engine or conf.snippet_engine
         if snippet_engine then
             -- User want to use a snippet engine instead of native handling
             local engines = snippet.engines

--- a/lua/neogen/init.lua
+++ b/lua/neogen/init.lua
@@ -241,6 +241,8 @@ end
 ---
 --- Note: We will only document `major` and `minor` versions, not `patch` ones. (only X and Y in X.Y.z)
 ---
+--- ## 2.20.0~
+---    - Add the `snippet_engine` parameter to `neogen.generator` (#202)
 --- ## 2.19.0~
 ---    - Add support for julia (`julia`) ! (#185)
 --- ## 2.18.0~
@@ -309,7 +311,7 @@ end
 ---     with multiple annotation conventions.
 ---@tag neogen-changelog
 ---@toc_entry Changes in neogen plugin
-neogen.version = "2.19.4"
+neogen.version = "2.20.0"
 --minidoc_afterlines_end
 
 return neogen


### PR DESCRIPTION
A (sort of) continuation of https://github.com/danymat/neogen/pull/201

I integrate Neogen + LuaSnip into one with this snippet:

<details>
<summary>Click to expand</summary>

```lua
--- Create LuaSnip snippets that can auto-expand Neogen's snippet engine.
---
--- @module 'my_custom.snippets._python_docstring'
---

local snippet_helper = require("my_custom.utilities.snippet_helper")
local luasnip = require("luasnip")
local snippet = luasnip.s
local dynamicNode = require("luasnip.nodes.dynamicNode").D
local snippetNode = require("luasnip.nodes.snippet").SN

--- Create a dynamic LuaSnip snippet-node whose contents are created by Neogen.
---
--- @param section string The Neogen section name to create a LuaSnip snippet.
--- @return LuaSnip.DynamicNode # The created node.
---
local function _make_section_snippet_node(section)
    return dynamicNode(
        1,
        function(args)
            local neogen = require("neogen")

            local lines = neogen.generate(
                -- TODO: Provide an explicit snippet engine (once there's an
                -- argument for it).
                {return_snippet = true, sections = {section}, snippet_engine = "luasnip"}
            )

            local nodes = luasnip.parser.parse_snippet(
                nil,
                table.concat(lines, "\n"),
                { trim_empty = false, dedent = true }
            )

            return snippetNode(nil, nodes)
        end
    )
end

--- Create a LuaSnip snippet for some `section`. Run it when `trigger` is found.
---
--- @param trigger string
---     A word that LuaSnip uses to decide when the snippet should run. e.g. `"Args:"`.
--- @param section string
---     The parts of a docstring that Neogen needs to generate.
--- @return LuaSnip.Snippet
---     The generated auto-complete snippet.
---
local function _make_section_snippet(trigger, section)
    return snippet(
        {
            trig=trigger,
            docstring=string.format(
                'Auto-fill a docstring\'s "%s" section, using Neogen',
                trigger
            ),
        },
        {
            _make_section_snippet_node(section)
        },
        {
            show_condition = function()
                return (
                    snippet_helper.in_docstring()
                    and snippet_helper.is_source_beginning(trigger)
                )
            end
        }
    )
end

return {
    _make_section_snippet("Args:", "parameter"),
    _make_section_snippet("Raises:", "throw"),
    _make_section_snippet("Returns:", "return"),
    _make_section_snippet("Yields:", "yield"),
}
```

(This later gets included to `luasnip.add_snippets("python", those_snippets_above)
</details>

With this, I can just write docstrings naturally like `Args:` and Neogen auto-expands the arguments for me.

The end result looks like this:

https://github.com/user-attachments/assets/3e44d2a7-54dd-4509-abec-a0f556467c85

https://github.com/user-attachments/assets/6b762a80-193c-474a-bec5-2079c3ff208a

(Sorry the recordings are a bit messed up)

Anyway being able to explicitly ask for the snippet engine means that a user can default to a different snippet engine in their configuration but run a different engine on-demand. This is useful as someone who wants to move to native LSP snippets someday.