### PR TITLE
feat: add support for `mini` snippet engine ('mini.snippets')

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ And this is done via the `snippet_engine` option in neogen's setup:
 
 - `snippet_engine` option will use provided engine to place the annotations:
 
-Currently supported: `luasnip`, `snippy`, `vsnip`, `nvim`.
+Currently supported: `luasnip`, `snippy`, `vsnip`, `nvim`, `mini`.
 
 ```lua
 require('neogen').setup({ snippet_engine = "luasnip" })

--- a/lua/neogen/init.lua
+++ b/lua/neogen/init.lua
@@ -241,10 +241,12 @@ end
 ---
 --- Note: We will only document `major` and `minor` versions, not `patch` ones. (only X and Y in X.Y.z)
 ---
+--- ## 2.20.0~
+---   - Add support for `mini` snippet engine  ! (see |neogen-snippet-integration|)
 --- ## 2.19.0~
----    - Add support for julia (`julia`) ! (#185)
+---   - Add support for julia (`julia`) ! (#185)
 --- ## 2.18.0~
----    - Add tests cases to tests/ for annotation generation with basic support for python (#174)
+---   - Add tests cases to tests/ for annotation generation with basic support for python (#174)
 --- ## 2.17.1~
 ---   - Python raises now supports `raise foo.Bar()` syntax
 --- ## 2.17.0~
@@ -309,7 +311,7 @@ end
 ---     with multiple annotation conventions.
 ---@tag neogen-changelog
 ---@toc_entry Changes in neogen plugin
-neogen.version = "2.19.4"
+neogen.version = "2.20.0"
 --minidoc_afterlines_end
 
 return neogen

--- a/lua/neogen/snippet.lua
+++ b/lua/neogen/snippet.lua
@@ -14,6 +14,7 @@ local conf = require("neogen.config").get()
 --- - `"snippy"` (https://github.com/dcampos/nvim-snippy)
 --- - `"vsnip"` (https://github.com/hrsh7th/vim-vsnip)
 --- - `"nvim"` (`:h vim.snippet`)
+--- - `"mini"` (https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-snippets.md)
 ---
 --- If you want to customize the placeholders, you can use `placeholders_text` option:
 --- >
@@ -141,6 +142,25 @@ snippet.engines.nvim = function(snip, pos)
     vim.api.nvim_win_set_cursor(0, { row + 1, 0 })
     snip = table.concat(snip, "\n")
     vim.snippet.expand(snip)
+end
+
+--- Expand snippet for mini.snippets engine
+---@param snip string the snippet to expand
+---@param pos table a tuple of row, col
+---@private
+snippet.engines.mini = function(snip, pos)
+    -- Check `MiniSnippets` is set up by the user
+    if _G.MiniSnippets == nil then
+        notify("'mini.snippets' is not set up, aborting...", vim.log.levels.ERROR)
+        return
+    end
+
+    local row = pos[1]
+    vim.api.nvim_buf_set_lines(0, row, row, true, { "" })
+    vim.api.nvim_win_set_cursor(0, { row + 1, 0 })
+    -- Use user configured `insert` method but fall back to default
+    local insert = MiniSnippets.config.expand.insert or MiniSnippets.default_insert
+    insert({ body = snip })
 end
 
 return snippet


### PR DESCRIPTION
This PR adds support for newly released [mini.snippets](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-snippets.md) and follows the path of #164. Plus minor documentation tweaks.