### PR TITLE
Feature/improve jsdoc

### DIFF
--- a/lua/neogen/configurations/javascript.lua
+++ b/lua/neogen/configurations/javascript.lua
@@ -8,7 +8,7 @@ local function_tree = {
         retrieve = "first",
         node_type = "formal_parameters",
         subtree = {
-            { retrieve = "all", node_type = "identifier", extract = true, as = i.Parameter },
+            { retrieve = "all", node_type = "identifier", recursive = true, extract = true, as = i.Parameter },
         },
     },
     {

--- a/lua/neogen/templates/jsdoc.lua
+++ b/lua/neogen/templates/jsdoc.lua
@@ -10,12 +10,12 @@ return {
 
     { nil, "/**", { type = { "class", "func" } } },
     { i.ClassName, " * @classdesc $1", { before_first_item = { " * ", " * @class" }, type = { "class" } } },
-    { i.Parameter, " * @param {any} %s $1", { type = { "func" } } },
+    { i.Parameter, " * @param {$1} %s - $1", { type = { "func" } } },
     {
         { i.Type, i.Parameter },
-        " * @param {%s} %s $1",
+        " * @param {%s} %s - $1",
         { required = i.Tparam, type = { "func" } },
     },
-    { i.Return, " * @returns {$1} $1", { type = { "func" } } },
+    { i.Return, " * @returns {$1} - $1", { type = { "func" } } },
     { nil, " */", { type = { "class", "func" } } },
 }


### PR DESCRIPTION
Improves jsdoc generation by looking recursively for identifiers into parameters, allow to detect destructured params that are `assignments`.
Also slightly improves jsdoc template to be able to set the type instead of putting `any` to all of them. 
Adds `-` before description to make it more readable, see [doc](https://jsdoc.app/tags-param).

Before:
```javascript
/**
 * @param {any} first - [TODO:description]
 * @returns {[TODO:return]} - [TODO:description]
 */
function foo(first, second = 'true', third = {}) {
  return 'bar'
}
```

After:
```javascript
/**
 * @param {any} first - [TODO:description]
 * @param {any} second - [TODO:description]
 * @param {any} third - [TODO:description]
 * @returns {[TODO:return]} - [TODO:description]
 */
function foo(first, second = 'true', third = {}) {
  return 'bar'
}
```