### PR TITLE
fix: consider injected languages when parsing current node to fix vue

### DIFF
--- a/lua/neogen/generator.lua
+++ b/lua/neogen/generator.lua
@@ -62,7 +62,7 @@ local function get_parent_node(filetype, node_type, language)
     local parser = vim.treesitter.get_parser(0, parser_name)
     local tstree = parser:parse()[1]
     local tree = tstree:root()
-    local current_node = vim.treesitter.get_node()
+    local current_node = vim.treesitter.get_node({ ignore_injections = false })
     local match_any = node_type == ANY_TYPE
     local target_node, target_type
     local locator = language.locator or default_locator


### PR DESCRIPTION
This fixes #169 . I am not sure whether we want to always consider injections. I guess a possibility is to only set `ignore_injections = false` for languages with injections, such as Vue or Svelte. Let me know what you think!