### PR TITLE
This commit adds support for R with roxygen2 annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ There is a list of supported languages and fields, with their annotation style
 | typescript      | [JSDoc](https://jsdoc.app) (`"jsdoc"`) <br> [TSDoc](https://tsdoc.org) (`"tsdoc"`)                                                                                                                                                                                               | `func`, `class`, `type`, `file` |
 | typescriptreact | [JSDoc](https://jsdoc.app) (`"jsdoc"`) <br> [TSDoc](https://tsdoc.org) (`"tsdoc"`)                                                                                                                                                                                               | `func`, `class`, `type`, `file` |
 | vue             | [JSDoc](https://jsdoc.app) (`"jsdoc"`)                                                                                                                                                                                                                                           | `func`, `class`, `type`, `file` |
+| R             | [roxygen2](https://roxygen2.r-lib.org) (`"roxygen2"`)                                                                                                                                                                                                                              | `func`                          | 
 
 ## Adding Languages
 

--- a/lua/neogen/configurations/R.lua
+++ b/lua/neogen/configurations/R.lua
@@ -1,0 +1,63 @@
+local template = require("neogen.template")
+local extractors = require("neogen.utilities.extractors")
+local nodes_utils = require("neogen.utilities.nodes")
+local i = require("neogen.types.template").item
+
+return {
+    parent = {
+        func = { "binary_operator" },
+    },
+    data = {
+        func = {
+            ["binary_operator"] = {
+                ["0"] = {
+                    extract = function(node)
+                        local function_name_node = node:child(0)
+                        local function_name = vim.treesitter.get_node_text(function_name_node, 0)
+                        local res = {}
+                        res["function_name"] = { function_name }
+
+                        local parameters_tree = {
+                            {
+                                retrieve = "first",
+                                node_type = "function_definition",
+                                subtree = {
+                                    {
+                                        retrieve = "first",
+                                        node_type = "parameters",
+                                        subtree = {
+                                            {
+                                                retrieve = "all",
+                                                node_type = "parameter",
+                                                subtree = {
+                                                    {
+                                                        retrieve = "first",
+                                                        node_type = "identifier|dots",
+                                                        extract = true,
+                                                        as = i.Parameter,
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        }
+
+                        local parameters_nodes = nodes_utils:matching_nodes_from(node, parameters_tree)
+                        local params_res = extractors:extract_from_matched(parameters_nodes)
+
+                        for k, v in pairs(params_res) do
+                            if k == "parameters" then
+                                res[k] = v
+                            end
+                        end
+
+                        return res
+                    end,
+                },
+            },
+        },
+    },
+    template = template:add_default_annotation("roxygen2"),
+}

--- a/lua/neogen/configurations/r.lua
+++ b/lua/neogen/configurations/r.lua
@@ -1,0 +1,63 @@
+local template = require("neogen.template")
+local extractors = require("neogen.utilities.extractors")
+local nodes_utils = require("neogen.utilities.nodes")
+local i = require("neogen.types.template").item
+
+return {
+    parent = {
+        func = { "binary_operator" },
+    },
+    data = {
+        func = {
+            ["binary_operator"] = {
+                ["0"] = {
+                    extract = function(node)
+                        local function_name_node = node:child(0)
+                        local function_name = vim.treesitter.get_node_text(function_name_node, 0)
+                        local res = {}
+                        res["function_name"] = { function_name }
+
+                        local parameters_tree = {
+                            {
+                                retrieve = "first",
+                                node_type = "function_definition",
+                                subtree = {
+                                    {
+                                        retrieve = "first",
+                                        node_type = "parameters",
+                                        subtree = {
+                                            {
+                                                retrieve = "all",
+                                                node_type = "parameter",
+                                                subtree = {
+                                                    {
+                                                        retrieve = "first",
+                                                        node_type = "identifier|dots",
+                                                        extract = true,
+                                                        as = i.Parameter,
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        }
+
+                        local parameters_nodes = nodes_utils:matching_nodes_from(node, parameters_tree)
+                        local params_res = extractors:extract_from_matched(parameters_nodes)
+
+                        for k, v in pairs(params_res) do
+                            if k == "parameters" then
+                                res[k] = v
+                            end
+                        end
+
+                        return res
+                    end,
+                },
+            },
+        },
+    },
+    template = template:add_default_annotation("roxygen2"),
+}

--- a/lua/neogen/templates/roxygen2.lua
+++ b/lua/neogen/templates/roxygen2.lua
@@ -1,7 +1,7 @@
 local i = require("neogen.types.template").item
 
 return {
-    { nil, "#' @title", { no_results = false, type = { "func" } } },
+    { nil, "#' @title $1", { no_results = false, type = { "func" } } },
     { nil, "#' @description", { no_results = false, type = { "func" } } },
     { i.Parameter, "#' @param %s" },
     { nil, "#' @return", { type = { "func" }, no_results = false } },

--- a/lua/neogen/templates/roxygen2.lua
+++ b/lua/neogen/templates/roxygen2.lua
@@ -1,0 +1,9 @@
+local i = require("neogen.types.template").item
+
+return {
+    { nil, "#' @title", { no_results = false, type = { "func" } } },
+    { nil, "#' @description", { no_results = false, type = { "func" } } },
+    { i.Parameter, "#' @param %s" },
+    { nil, "#' @return", { type = { "func" }, no_results = false } },
+    { nil, "#' @export", { type = { "func" }, no_results = false } }
+}


### PR DESCRIPTION
fixes #216 
Always adds 'return' tag.
- R always returns a value, even with no return statement, and even if you call invisible(...) at the end of the function. Always adds 'export' tag
- Export tag added because it is easier to delete a line then type "#'" as for most people I expect the single quote will autoclose