### PR TITLE
Removing trailing space for attributes keyword

### DIFF
--- a/lua/neogen/templates/google_docstrings.lua
+++ b/lua/neogen/templates/google_docstrings.lua
@@ -17,7 +17,7 @@ return {
     { { i.Parameter, i.Type }, "    %s: $1", { required = i.Tparam, type = { "func" } } },
     { i.ArbitraryArgs, "    %s: $1", { type = { "func" } } },
     { i.Kwargs, "    %s: $1", { type = { "func" } } },
-    { i.ClassAttribute, "    %s: $1", { before_first_item = { "", "Attributes: " } } },
+    { i.ClassAttribute, "    %s: $1", { before_first_item = { "", "Attributes:" } } },
     { i.HasReturn, "", { type = { "func" } } },
     { i.HasReturn, "Returns:", { type = { "func" } } },
     { i.HasReturn, "    $1", { type = { "func" } } },


### PR DESCRIPTION
Great plugin, but that trailing space is a thorn in my side.