### PR TITLE
C# improvements

### DIFF
--- a/lua/neogen/configurations/cs.lua
+++ b/lua/neogen/configurations/cs.lua
@@ -76,8 +76,7 @@ return {
                         local nodes = nodes_utils:matching_nodes_from(node, tree)
                         local res = extractors:extract_from_matched(nodes)
 
-                        local has_no_return = node:type() == "constructor_declaration"
-                                              or is_void(res.return_statement);
+                        local has_no_return = node:type() == "constructor_declaration" or is_void(res.return_statement)
                         if has_no_return then
                             res.return_statement = nil
                         else
@@ -94,7 +93,7 @@ return {
                 ["0"] = {
                     extract = function(node)
                         local tree = {
-                            get_type_parameters_tree()
+                            get_type_parameters_tree(),
                         }
                         local nodes = nodes_utils:matching_nodes_from(node, tree)
                         local res = extractors:extract_from_matched(nodes)
@@ -164,7 +163,7 @@ return {
                         local nodes = nodes_utils:matching_nodes_from(node, tree)
                         local res = extractors:extract_from_matched(nodes)
 
-                        local has_getter = false;
+                        local has_getter = false
                         if res.return_statement then
                             for _, value in ipairs(res.return_statement) do
                                 if vim.startswith(value, "get") then

--- a/lua/neogen/configurations/cs.lua
+++ b/lua/neogen/configurations/cs.lua
@@ -3,6 +3,50 @@ local nodes_utils = require("neogen.utilities.nodes")
 local template = require("neogen.template")
 local i = require("neogen.types.template").item
 
+local is_void = function(return_statement)
+    if not return_statement then
+        return
+    end
+    for _, value in ipairs(return_statement) do
+        if value == "void" then
+            return true
+        end
+    end
+    return false
+end
+
+local get_parameters_tree = function()
+    return {
+        retrieve = "first",
+        node_type = "parameter_list",
+        subtree = {
+            {
+                retrieve = "all",
+                node_type = "parameter",
+                subtree = {
+                    { position = -1, extract = true, as = i.Parameter },
+                },
+            },
+        },
+    }
+end
+
+local get_type_parameters_tree = function()
+    return {
+        retrieve = "first",
+        node_type = "type_parameter_list",
+        subtree = {
+            {
+                retrieve = "all",
+                node_type = "type_parameter",
+                subtree = {
+                    { position = 1, extract = true, as = i.Tparam },
+                },
+            },
+        },
+    }
+end
+
 return {
     parent = {
         func = {
@@ -12,7 +56,7 @@ return {
             "delegate_declaration",
             "conversion_operator_declaration",
         },
-        class = { "class_declaration", "interface_declaration" },
+        class = { "interface_declaration", "class_declaration", "record_declaration", "struct_declaration" },
         type = { "field_declaration", "property_declaration", "event_field_declaration", "indexer_declaration" },
     },
     data = {
@@ -21,42 +65,23 @@ return {
                 ["0"] = {
                     extract = function(node)
                         local tree = {
+                            get_type_parameters_tree(),
+                            get_parameters_tree(),
                             {
-                                retrieve = "first",
-                                node_type = "parameter_list",
-                                subtree = {
-                                    {
-                                        retrieve = "all",
-                                        node_type = "parameter",
-                                        subtree = {
-                                            { position = 2, extract = true, as = i.Parameter },
-                                        },
-                                    },
-                                },
-                            },
-                            {
-                                retrieve = "first",
-                                node_type = "type_parameter_list",
-                                subtree = {
-                                    {
-                                        retrieve = "all",
-                                        node_type = "type_parameter",
-                                        subtree = {
-                                            { position = 1, extract = true, as = i.Tparam },
-                                        },
-                                    },
-                                },
-                            },
-                            {
-                                position = 1,
+                                retrieve = "all",
                                 extract = true,
                                 as = i.Return,
                             },
                         }
                         local nodes = nodes_utils:matching_nodes_from(node, tree)
                         local res = extractors:extract_from_matched(nodes)
-                        if res.return_statement[1] == "void" then
+
+                        local has_no_return = node:type() == "constructor_declaration"
+                                              or is_void(res.return_statement);
+                        if has_no_return then
                             res.return_statement = nil
+                        else
+                            res.return_statement = { res.return_statement[1] }
                         end
                         res.identifier = res["_"]
                         return res
@@ -65,23 +90,25 @@ return {
             },
         },
         class = {
-            ["class_declaration|interface_declaration"] = {
+            ["interface_declaration"] = {
                 ["0"] = {
                     extract = function(node)
                         local tree = {
-                            {
-                                retrieve = "first",
-                                node_type = "type_parameter_list",
-                                subtree = {
-                                    {
-                                        retrieve = "all",
-                                        node_type = "type_parameter",
-                                        subtree = {
-                                            { position = 1, extract = true, as = i.Tparam },
-                                        },
-                                    },
-                                },
-                            },
+                            get_type_parameters_tree()
+                        }
+                        local nodes = nodes_utils:matching_nodes_from(node, tree)
+                        local res = extractors:extract_from_matched(nodes)
+                        res.identifier = res["_"]
+                        return res
+                    end,
+                },
+            },
+            ["class_declaration|record_declaration|struct_declaration"] = {
+                ["0"] = {
+                    extract = function(node)
+                        local tree = {
+                            get_type_parameters_tree(),
+                            get_parameters_tree(),
                         }
                         local nodes = nodes_utils:matching_nodes_from(node, tree)
                         local res = extractors:extract_from_matched(nodes)
@@ -127,9 +154,8 @@ return {
                                 subtree = {
                                     {
                                         retrieve = "all",
-                                        node_type = "return_statement",
+                                        node_type = "accessor_declaration",
                                         as = i.Return,
-                                        recursive = true,
                                         extract = true,
                                     },
                                 },
@@ -137,6 +163,22 @@ return {
                         }
                         local nodes = nodes_utils:matching_nodes_from(node, tree)
                         local res = extractors:extract_from_matched(nodes)
+
+                        local has_getter = false;
+                        if res.return_statement then
+                            for _, value in ipairs(res.return_statement) do
+                                if vim.startswith(value, "get") then
+                                    has_getter = true
+                                    break
+                                end
+                            end
+                        end
+                        if has_getter then
+                            res.return_statement = { "get" }
+                        else
+                            res.return_statement = nil
+                        end
+
                         return res
                     end,
                 },

--- a/lua/neogen/configurations/cs.lua
+++ b/lua/neogen/configurations/cs.lua
@@ -56,8 +56,8 @@ return {
             "delegate_declaration",
             "conversion_operator_declaration",
         },
-        class = { "interface_declaration", "class_declaration", "record_declaration", "struct_declaration" },
-        type = { "field_declaration", "property_declaration", "event_field_declaration", "indexer_declaration" },
+        class = { "interface_declaration", "class_declaration", "record_declaration", "struct_declaration", "enum_declaration" },
+        type = { "field_declaration", "property_declaration", "event_field_declaration", "indexer_declaration", "enum_member_declaration" },
     },
     data = {
         func = {
@@ -116,9 +116,16 @@ return {
                     end,
                 },
             },
+            ["enum_declaration"] = {
+                ["0"] = {
+                    extract = function()
+                        return {}
+                    end,
+                }
+            },
         },
         type = {
-            ["field_declaration|property_declaration|event_field_declaration"] = {
+            ["field_declaration|property_declaration|event_field_declaration|enum_member_declaration"] = {
                 ["0"] = {
                     extract = function()
                         return {}

--- a/lua/neogen/templates/xmldoc.lua
+++ b/lua/neogen/templates/xmldoc.lua
@@ -8,7 +8,7 @@ return {
     { nil, "/// <summary>", {} },
     { nil, "/// $1", {} },
     { nil, "/// </summary>", {} },
-    { i.Parameter, '/// <param name="%s">$1</param>', { type = { "func", "type" } } },
     { i.Tparam, '/// <typeparam name="%s">$1</typeparam>', { type = { "func", "class" } } },
+    { i.Parameter, '/// <param name="%s">$1</param>', { type = { "func", "type", "class" } } },
     { i.Return, "/// <returns>$1</returns>", { type = { "func", "type" } } },
 }

--- a/lua/neogen/utilities/nodes.lua
+++ b/lua/neogen/utilities/nodes.lua
@@ -56,7 +56,7 @@ return {
     --- @param parent TSNode the parent node
     --- @param tree table a nested table : { retrieve = "all|first", node_type = node_name, subtree = tree, recursive = true }
     --- If you want to extract the node, do not specify the subtree and instead: extract = true
-    --- Optional: you can specify position = number instead of retrieve, and it will fetch the child node at position number
+    --- Optional: you can specify position = number instead of retrieve, and it will fetch the child node at position number, if position == -1, then last child is taken
     --- @param result? table the table of results
     --- @return table result a table of k,v where k are node_types and v all matched nodes
     matching_nodes_from = function(self, parent, tree, result)
@@ -74,6 +74,9 @@ return {
             -- Only keep the node with custom position
             if not subtree.retrieve then
                 assert(type(subtree.position) == "number", "please require position if retrieve is nil")
+                if subtree.position == -1 then
+                    subtree.position = #matched
+                end
                 matched = { matched[subtree.position] }
             end
 

--- a/lua/neogen/utilities/nodes.lua
+++ b/lua/neogen/utilities/nodes.lua
@@ -74,10 +74,11 @@ return {
             -- Only keep the node with custom position
             if not subtree.retrieve then
                 assert(type(subtree.position) == "number", "please require position if retrieve is nil")
-                if subtree.position == -1 then
-                    subtree.position = #matched
+                local position = subtree.position
+                if position == -1 then
+                    position = #matched
                 end
-                matched = { matched[subtree.position] }
+                matched = { matched[position] }
             end
 
             if subtree.recursive then


### PR DESCRIPTION
# Summary
Found some issues in C# doc generation and decided to fix it.
Number 4. of changes list fixes #181.

# Changes
## 1. Fix "returns" insertion
### 1.1 Method returning void
Not insert if void. Currently checks for first child in `ret.return_statement`, but it's not enough, because modifiers like `public`, `static` etc can be put before return type.

before:
 ```cs
class TestClass
{
    /// <summary>
    /// 
    /// </summary>
    /// <param name="p1"></param>
    /// <returns></returns>
    public void TestMethod(int p1)
    {
    }
}
```
after:
 ```cs
class TestClass
{
    /// <summary>
    /// 
    /// </summary>
    /// <param name="p1"></param>
    public void TestMethod(int p1)
    {
    }
}
```
### 1.2 Constructor
Not insert at all. Currently inserts every time.

before:
```cs
class TestClass
{
    /// <summary>
    /// 
    /// </summary>
    /// <param name="p"></param>
    /// <returns></returns>
    public TestClass(int p)
    {
    }
}
```
after:
```cs
class TestClass
{
    /// <summary>
    /// 
    /// </summary>
    /// <param name="p"></param>
    public TestClass(int p)
    {
    }
}
```
### 1.3 Indexer
Change logic from search for return statement to checking if getter is present, because `get` might not contain return statement, but instead `=>`, also might not contain body at all in interfaces.
before:
```cs
interface IndexerTest
{
    /// <summary>
    /// 
    /// </summary>
    /// <param name="i"></param>
    public IndexerTest this[int i] { set; }

    /// <summary>
    /// 
    /// </summary>
    /// <param name="i"></param>
    public IndexerTest this[int i] { get; }

    /// <summary>
    /// 
    /// </summary>
    /// <param name="i"></param>
    public IndexerTest this[int i] { get; set; }

    /// <summary>
    /// 
    /// </summary>
    /// <param name="i"></param>
    public IndexerTest this[int i] { get => null; set { } }

    /// <summary>
    /// 
    /// </summary>
    /// <param name="i"></param>
    /// <returns></returns>
    public IndexerTest this[int i] { get { return null; } }
}
```
after:
```cs
interface IndexerTest
{
    /// <summary>
    /// 
    /// </summary>
    /// <param name="i"></param>
    public IndexerTest this[int i] { set; }

    /// <summary>
    /// 
    /// </summary>
    /// <param name="i"></param>
    /// <returns></returns>
    public IndexerTest this[int i] { get; }

    /// <summary>
    /// 
    /// </summary>
    /// <param name="i"></param>
    /// <returns></returns>
    public IndexerTest this[int i] { get; set; }

    /// <summary>
    /// 
    /// </summary>
    /// <param name="i"></param>
    /// <returns></returns>
    public IndexerTest this[int i] { get => null; set { } }

    /// <summary>
    /// 
    /// </summary>
    /// <param name="i"></param>
    /// <returns></returns>
    public IndexerTest this[int i] { get { return null; } }
}
```
## 2. Fix parameter generation when attribute is attached to it
Currently gets 2-nd position of children in parameter. Changed it to take last child instead.

before:
```cs
class AttributeTest
{
    /// <summary>
    /// 
    /// </summary>
    /// <param name="string"></param>
    /// <param name="p2"></param>
    /// <returns></returns>
    private string TestAttribute([Attr] string p, int p2)
    {
    }
}
```
after:
```cs
class AttributeTest
{
    /// <summary>
    /// 
    /// </summary>
    /// <param name="p"></param>
    /// <param name="p2"></param>
    /// <returns></returns>
    private string TestAttribute([Attr] string p, int p2)
    {
    }
}
```
## 3. Added support for primary constructors
before:
```cs
/// <summary>
/// 
/// </summary>
class PrimaryConstructorTest(int p1, string p2)
{
}
```
after:
```cs
/// <summary>
/// 
/// </summary>
/// <param name="p1"></param>
/// <param name="p2"></param>
class PrimaryConstructorTest(int p1, string p2)
{
}
```
## 4. Added support for records, record structs, structs
Same logic as for classes is applied.

```cs
/// <summary>
/// 
/// </summary>
/// <typeparam name="T1"></typeparam>
/// <typeparam name="T2"></typeparam>
/// <typeparam name="T3"></typeparam>
/// <param name="P1"></param>
record RecordTest<T1, T2, T3>(int P1);

/// <summary>
/// 
/// </summary>
/// <typeparam name="T1"></typeparam>
/// <typeparam name="T2"></typeparam>
/// <typeparam name="T3"></typeparam>
/// <param name="P1"></param>
/// <param name="P2"></param>
record struct RecordStructTest<T1, T2, T3>(string P1, int P2);

/// <summary>
/// 
/// </summary>
/// <typeparam name="T"></typeparam>
/// <param name="a"></param>
/// <param name="b"></param>
struct StructTest<T>(Type1 a, int b)
{
}
```
## 5. Added enum support

```cs
/// <summary>
/// 
/// </summary>
enum TestEnum
{
    /// <summary>
    /// 
    /// </summary>
    Variant1,
    /// <summary>
    /// 
    /// </summary>
    Variant2,
}
```
## 6. Change parameters and type parameters order for xmldoc (type parameters should go first)
before:
```cs
class TypeParametersOrder
{
    /// <summary>
    /// 
    /// </summary>
    /// <param name="p1"></param>
    /// <param name="p2"></param>
    /// <typeparam name="T1"></typeparam>
    /// <typeparam name="T2"></typeparam>
    /// <returns></returns>
    public void Test<T1, T2>(string p1, string p2)
    {
    }
}
```
after:
```cs
class TypeParametersOrder
{
    /// <summary>
    /// 
    /// </summary>
    /// <typeparam name="T1"></typeparam>
    /// <typeparam name="T2"></typeparam>
    /// <param name="p1"></param>
    /// <param name="p2"></param>
    public void Test<T1, T2>(string p1, string p2)
    {
    }
}
```